### PR TITLE
[fix] font display on non-apple plattforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ dependencies:
     emoji_selector: ^0.0.6
 ```
 
+[Optional] If you need support for Plattfroms that don't have the `Apple Color Emoji` font installed (e.g. Linux, Web, ...), download Noto Emoji Font from https://github.com/googlefonts/noto-emoji) and add it to your `pubspec.yaml`:
+```yaml
+flutter:
+  fonts:
+    - family: Noto Emoji
+      fonts:
+        - asset: fonts/NotoEmoji/NotoEmoji.ttf
+```
+
 You can then easily embed the Emoji Selector Widget anywhere in your application:
 ```dart
 EmojiSelector(

--- a/lib/src/emoji_page.dart
+++ b/lib/src/emoji_page.dart
@@ -39,6 +39,7 @@ class EmojiPage extends StatelessWidget {
                       fontSize: 24.0,
                       fontFamily:
                           'Apple Color Emoji', // Investigate what to use on other platforms
+                      fontFamilyFallback: ["Noto Emoji"],
                     ),
                   ),
                 ),


### PR DESCRIPTION
Use the [Noto Emoji Font](https://github.com/googlefonts/noto-emoji) to resolves displaying icons on Linux.
Should also resolve #6 (I couldn't test it yet, though).